### PR TITLE
Enable the "stop on build" functionality by default for new installat…

### DIFF
--- a/Settings.cs
+++ b/Settings.cs
@@ -7,7 +7,7 @@ namespace EinarEgilsson.StopOnFirstBuildError
 {
     public class Settings : DialogPage
     {
-        private bool _enabled;
+        private bool _enabled = true;
         private bool _showErrorList;
 
         public event EventHandler EnabledChanged;


### PR DESCRIPTION
A few folks at my office were surprised when we installed this and it didn't work. Then we found that (in VS 2015 at least) the feature is disabled by default. Setting the flag to true on object construction seems to fix it.